### PR TITLE
Enhance documentation and add Vercel configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,114 @@
-<div align="center">
-<img width="1200" height="475" alt="GHBanner" src="https://github.com/user-attachments/assets/0aa67016-6eaf-458a-adb2-6e31a0763ed6" />
-</div>
+# Co-Drawing App
 
-# Run and deploy your AI Studio app
+A collaborative drawing assistant powered by Google Gemini, built with React and Vite. The app lets you describe an illustration idea in natural language and iteratively refine the artwork with AI-generated guidance.
 
-This contains everything you need to run your app locally.
+## Features
 
-View your app in AI Studio: https://ai.studio/apps/drive/16cK5lvZUPTT-jf82cN2dk8ZaHoeRmHbU
+- 🎨 Interactive drawing board with AI-driven suggestions
+- 💡 Prompt-based idea refinement and iteration
+- ⚡ Lightning-fast local development with Vite
+- ☁️ Ready for one-click deployment to Vercel
 
-## Run Locally
+## Getting Started
 
-**Prerequisites:**  Node.js
+### Prerequisites
 
+- [Node.js](https://nodejs.org/) 18 or later
+- A Google Gemini API key
 
-1. Install dependencies:
-   `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
-   `npm run dev`
+### Installation
+
+```bash
+npm install
+```
+
+### Environment Variables
+
+Create a `.env.local` file at the project root with your Gemini API key:
+
+```bash
+GEMINI_API_KEY=your_api_key_here
+```
+
+### Local Development
+
+Start the development server with hot reloading:
+
+```bash
+npm run dev
+```
+
+The Vite dev server prints the local URL (typically `http://localhost:5173`).
+
+### Production Build
+
+Create an optimized production build:
+
+```bash
+npm run build
+```
+
+Preview the production bundle locally:
+
+```bash
+npm run preview
+```
+
+## Deploying to Vercel
+
+You can deploy directly from the Vercel dashboard or via the CLI.
+
+### Option 1: Vercel Dashboard
+
+1. Push your code to a GitHub, GitLab, or Bitbucket repository.
+2. In the [Vercel dashboard](https://vercel.com/dashboard), select **Add New… → Project** and import the repository.
+3. When prompted for build settings, set:
+   - **Framework Preset:** `Vite`
+   - **Build Command:** `npm run build`
+   - **Output Directory:** `dist`
+4. Add an environment variable named `GEMINI_API_KEY` with your key.
+5. Click **Deploy**. Vercel will build and deploy your app automatically.
+
+### Option 2: Vercel CLI
+
+1. Install the CLI (one time):
+   ```bash
+   npm i -g vercel
+   ```
+2. Login and link the project:
+   ```bash
+   vercel login
+   vercel
+   ```
+3. During the `vercel` command, accept the detected Vite configuration, set the build command to `npm run build`, and the output directory to `dist`.
+4. Add the environment variable:
+   ```bash
+   vercel env add GEMINI_API_KEY
+   ```
+5. Deploy:
+   ```bash
+   vercel --prod
+   ```
+
+Vercel will handle future deployments automatically when you push to the connected Git branch.
+
+## Project Structure
+
+```
+├── Home.tsx          # Main React component for the drawing experience
+├── index.tsx         # App entry point
+├── index.css         # Global styles
+├── index.html        # Base HTML template used by Vite
+├── vite.config.ts    # Vite configuration
+└── tsconfig.json     # TypeScript configuration
+```
+
+## Troubleshooting
+
+- Ensure `GEMINI_API_KEY` is set in both local `.env.local` and Vercel project settings.
+- If the dev server fails to start, delete `node_modules` and reinstall dependencies with `npm install`.
+- For additional Vite configuration options, see the [Vite documentation](https://vitejs.dev/).
+
+## License
+
+This project is provided as-is without an explicit license. Contact the original author for reuse permissions.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": "vite"
+}


### PR DESCRIPTION
## Summary
- rewrite the README with detailed setup, environment, and Vercel deployment guidance
- add a `vercel.json` configuration so Vercel uses the Vite build output

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3d4b9c3dc8320aa2e565af9a7e2ad